### PR TITLE
Adjust purpose of folder module

### DIFF
--- a/src/adderbox/folder.py
+++ b/src/adderbox/folder.py
@@ -164,6 +164,18 @@ class Cmp(Protocol):
     def __lt__(self, other, /) -> bool: ...
 
 
+def _eq[T: Cmp](a: T, b: T) -> bool:
+    """
+    Check if two items are equal by less than operator.
+
+    Useful since that all Python object has operator== implemented by default,
+    but it's defined by object identity, not object value.
+
+    It's only semantically correct if the relation is a total order.
+    """
+    return not a < b and not b < a
+
+
 class C(enum.Enum):
     """Color enum for RB Tree"""
 
@@ -446,18 +458,6 @@ class ByKey[K: Cmp, V](NamedTuple):
         if self.value is None:
             raise ValueError("expect value but got None")
         return self.value
-
-
-def _eq[T: Cmp](a: T, b: T) -> bool:
-    """
-    Check if two items are equal by less than operator.
-
-    Useful since that all Python object has operator== implemented by default,
-    but it's defined by object identity, not object value.
-
-    It's only semantically correct if the relation is a total order.
-    """
-    return not a < b and not b < a
 
 
 class _SkipNode[K: Any, V: Any]:

--- a/src/adderbox/folder.py
+++ b/src/adderbox/folder.py
@@ -417,19 +417,19 @@ class RbTree[K: Cmp](Container[K], Reversible[K]):
         return _rb_traverse(self._root, reverse=reverse)
 
 
-class _None:
-    """Customized None type to avoid type collision"""
-
-
 class ByKey[K: Cmp, V](NamedTuple):
     """
     Key value type that support comparison by key only
 
     Useful for building a mapping upon a primitive container.
+
+    It's not possible to use None as value type here.
     """
 
+    # TODO: support type hint to ensure value type is not None
+
     key: K
-    value: V | _None
+    value: V | None
 
     def __lt__(self, other) -> bool:
         if not isinstance(other, ByKey):
@@ -439,11 +439,11 @@ class ByKey[K: Cmp, V](NamedTuple):
     @classmethod
     def only(cls, key: K) -> ByKey[K, V]:
         """Construct a pair that only contains key, useful for comparing."""
-        return cls(key, cast(V, _None()))
+        return cls(key, cast(V, None))
 
     def val(self) -> V:
         """Convenient value getter to ensure existence"""
-        if isinstance(self.value, _None):
+        if self.value is None:
             raise ValueError("expect value but got None")
         return self.value
 

--- a/tests/test_adderbox/test_folder.py
+++ b/tests/test_adderbox/test_folder.py
@@ -61,35 +61,6 @@ class TestFolder(unittest.TestCase):
             tree.remove(val)
         self.assertEqual([0, 0, 1, 1, 2, 3, 6, 7], list(tree))
 
-    def test_tree_map(self) -> None:
-
-        container = folder.TreeMap({1: "2", 3: "4"}.items())
-
-        self.assertEqual("2", container[1])
-        self.assertEqual([1, 3], list(iter(container)))
-
-        del container[3]
-        container[1] = "5"
-        container[0] = "2"
-        self.assertEqual([0, 1], list(container))
-
-    def test_multi_set(self) -> None:
-
-        container = folder.MultiSet(reversed(range(8)))
-
-        self.assertTrue(2 in container)
-        self.assertTrue(9 not in container)
-
-        self.assertEqual(list(range(8)), list(container))
-
-        for val in range(4):
-            container.add(val)
-        self.assertEqual(12, len(container))
-        for val in range(2, 6):
-            container.discard(val)
-        self.assertEqual(8, len(container))
-        self.assertEqual([0, 0, 1, 1, 2, 3, 6, 7], list(container))
-
 
 class TestSkipList(unittest.TestCase):
 


### PR DESCRIPTION
Instead of providing generic mapping container, focus on lower level stuffs.

- Remove TreeMap and MultiSet types and make ByKey a public type.
- Simplify RB Tree, and emphasize the ability to iterate at both direction
- Simplify SkipList, and hint the ability to access by index

Access by index will be implemented separately.